### PR TITLE
Added arm64 support to docker image

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -1,34 +1,70 @@
-name: Build and push to repository
+name: Build and push to registry
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "dev" ]
+    tags: [ "v*.*.*" ]
+  pull_request:
+    branches: [ "main", "dev" ]
+  workflow_dispatch:
+
+permissions:
+  packages: write
 
 jobs:
   build-and-push:
-    name: Build Docker image and push to repository
+    name: Build Docker image and push to registry
     runs-on: ubuntu-latest
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
-        
+
       - name: Set up Docker buildx
         id: buildx
         uses: docker/setup-buildx-action@v2
-        
-      - name: Login to repository
+
+      - name: Login to private registry
         uses: docker/login-action@v2
         with:
           registry: ${{ secrets.REGISTRY_URL }}
           username: ${{ secrets.REGISTRY_USERNAME }}
           password: ${{ secrets.REGISTRY_PASSWORD }}
-        
+
+      - name: Login to GitHub's container registry
+        if: github.event_name != 'pull_request'
+        uses: docker/login-action@v2
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Generate image metadata
+        id: spoticord # used in next step
+        uses: docker/metadata-action@v5
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            ghcr.io/spoticord/spoticord
+            ${{ secrets.REGISTRY_URL }}/spoticord/spoticord
+          # Docker tags based on the following events/attributes
+          tags: |
+            type=raw,value=latest,enable={{is_default_branch}}
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=sha
+
       - name: Build image and push to registry
-        uses: docker/build-push-action@v2
+        uses: docker/build-push-action@v5
         with:
           context: .
-          file: ./Dockerfile
-          tags: |
-            ${{ secrets.REGISTRY_URL }}/spoticord/spoticord:latest
-          push: ${{ github.ref == 'refs/heads/main' }}
+          platforms: linux/amd64,linux/arm64
+          push: ${{ github.event_name != 'pull_request' }}
+          tags: ${{ steps.spoticord.outputs.tags }}
+          labels: ${{ steps.spoticord.outputs.labels }}
+          # Some basic caching of the layers...
+          cache-from: ghcr.io/spoticord/spoticord:latest-cache
+          cache-to: ghcr.io/spoticord/spoticord:latest-cache

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,44 @@
 # Builder
-FROM rust:1.72.1-buster as builder
+FROM --platform=linux/amd64 rust:1.72.1-buster as builder
 
 WORKDIR /app
 
 # Add extra build dependencies here
-RUN apt-get update && apt-get install -y cmake
+RUN apt-get update && apt-get install -yqq \
+    cmake gcc-aarch64-linux-gnu  binutils-aarch64-linux-gnu 
 
 COPY . .
 
-# Remove `--features stats` if you want to deploy without stats collection
-RUN cargo install --path . --features stats
+RUN rustup target add x86_64-unknown-linux-gnu aarch64-unknown-linux-gnu 
+
+# Remove `--features=stats` if you want to deploy without stats collection
+RUN cargo build --features=stats --release \
+    --target=x86_64-unknown-linux-gnu --target=aarch64-unknown-linux-gnu
 
 # Runtime
 FROM debian:buster-slim
 
-WORKDIR /app
+ARG TARGETPLATFORM
+ENV TARGETPLATFORM=$TARGETPLATFORM
 
 # Add extra runtime dependencies here
-RUN apt-get update && apt-get install -y openssl ca-certificates && rm -rf /var/lib/apt/lists/*
+RUN apt-get update && apt-get install -yqq --no-install-recommends \
+    openssl ca-certificates && rm -rf /var/lib/apt/lists/*
 
-# Copy spoticord binary from builder
-COPY --from=builder /usr/local/cargo/bin/spoticord ./spoticord
+# Copy spoticord binaries from builder to /tmp
+COPY --from=builder \
+    /app/target/x86_64-unknown-linux-gnu/release/spoticord /tmp/x86_64
+COPY --from=builder \
+    /app/target/aarch64-unknown-linux-gnu/release/spoticord /tmp/aarch64
 
-CMD ["./spoticord"]
+# Copy appropiate binary for target arch from /tmp  
+RUN if [ "$TARGETPLATFORM" = "linux/amd64" ]; then \
+        cp /tmp/x86_64 /usr/local/bin/spoticord; \
+    elif [ "$TARGETPLATFORM" = "linux/arm64" ]; then \
+        cp /tmp/aarch64 /usr/local/bin/spoticord; \
+    fi
+
+# Delete unused binaries
+RUN rm -rvf /tmp/x86_64 /tmp/aarch64
+
+ENTRYPOINT [ "/usr/local/bin/spoticord" ]


### PR DESCRIPTION
I've modified the Dockerfile and build-push workflow to make it work. It should now additionally push to ghcr.io and cache to it too slightly reducing the time for image generation. Not entirely sure if the new workflow still works as intended before but everything I've added seems to work on my end and it would suggest that it should work just fine.

Using cross-compilation as emulating an entire architecture with buildx will take way too long, it should be relatively easy to add support for other architectures.  

Additionally I've updated all the workflow actions and tested them, should result in no more warnings on the workflow run page :p 

I've not ran any tests with the actual source code as I've not touched it.