### PR TITLE
Make GitHub actions use vars instead of hardcoded values

### DIFF
--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -32,7 +32,7 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - uses: Entepotenz/change-string-case-action@v1 # https://github.com/orgs/community/discussions/10553
+      - uses: Entepotenz/change-string-case-action-min-dependencies@v1 # https://github.com/orgs/community/discussions/10553
         id: repo-uri-string
         with:
           string: ghcr.io/${{ github.repository }}

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -32,13 +32,17 @@ jobs:
           username: ${{ github.repository_owner }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - uses: Entepotenz/change-string-case-action@v1 # https://github.com/orgs/community/discussions/10553
+        id: repo-uri-string
+        with:
+          string: ghcr.io/${{ github.repository }}
+
       - name: Generate image metadata
-        id: spoticord # used in next step
+        id: docker-meta # used in next step
         uses: docker/metadata-action@v5
         with:
           # list of Docker images to use as base name for tags
-          images: |
-            ghcr.io/${{ github.repository }}
+          images: ${{ steps.repo-uri-string.outputs.lowercase }}
           # Docker tags based on the following events/attributes
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
@@ -55,8 +59,8 @@ jobs:
           context: .
           platforms: linux/amd64,linux/arm64
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ steps.spoticord.outputs.tags }}
-          labels: ${{ steps.spoticord.outputs.labels }}
+          tags: ${{ steps.docker-meta.outputs.tags }}
+          labels: ${{ steps.docker-meta.outputs.labels }}
           # Some basic caching of the layers...
-          cache-from: ghcr.io/${{ github.repository }}:latest-cache
-          cache-to: ghcr.io/${{ github.repository }}:latest-cache
+          cache-from: ${{ steps.repo-uri-string.outputs.lowercase }}:latest-cache
+          cache-to: ${{ steps.repo-uri-string.outputs.lowercase }}:latest-cache

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -39,7 +39,7 @@ jobs:
         with:
           # list of Docker images to use as base name for tags
           images: |
-            ghcr.io/spoticordmusic/spoticord
+            ghcr.io/kankerdev/spoticord/bot
           # Docker tags based on the following events/attributes
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
@@ -59,5 +59,5 @@ jobs:
           tags: ${{ steps.spoticord.outputs.tags }}
           labels: ${{ steps.spoticord.outputs.labels }}
           # Some basic caching of the layers...
-          cache-from: ghcr.io/spoticordmusic/spoticord:latest-cache
-          cache-to: ghcr.io/spoticordmusic/spoticord:latest-cache
+          cache-from: ghcr.io/kankerdev/spoticord/bot:latest-cache
+          cache-to: ghcr.io/kankerdev/spoticord/bot:latest-cache

--- a/.github/workflows/build-push.yml
+++ b/.github/workflows/build-push.yml
@@ -8,15 +8,14 @@ on:
     branches: [ "main", "dev" ]
   workflow_dispatch:
 
+permissions:
+  packages: write
+  contents: read
+      
 jobs:
   build-and-push:
     name: Build Docker image and push to registry
     runs-on: ubuntu-latest
-    
-    permissions:
-      packages: write
-      contents: read
-
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
@@ -39,7 +38,7 @@ jobs:
         with:
           # list of Docker images to use as base name for tags
           images: |
-            ghcr.io/kankerdev/spoticord/bot
+            ghcr.io/${{ github.repository }}
           # Docker tags based on the following events/attributes
           tags: |
             type=raw,value=latest,enable={{is_default_branch}}
@@ -59,5 +58,5 @@ jobs:
           tags: ${{ steps.spoticord.outputs.tags }}
           labels: ${{ steps.spoticord.outputs.labels }}
           # Some basic caching of the layers...
-          cache-from: ghcr.io/kankerdev/spoticord/bot:latest-cache
-          cache-to: ghcr.io/kankerdev/spoticord/bot:latest-cache
+          cache-from: ghcr.io/${{ github.repository }}:latest-cache
+          cache-to: ghcr.io/${{ github.repository }}:latest-cache


### PR DESCRIPTION
To avoid [this mess](https://github.com/SpoticordMusic/spoticord/actions/runs/6292071862) in the future, the CI should now just use GitHub provided variables to decide what registry URL to push to. 

Additionally it will make it a lot nicer for people who fork this repo in the future!